### PR TITLE
ci: add a workflow for a dispatch/scheduled sync from upstream latest tag

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,35 @@
+name: Sync with Upstream
+
+on:
+  schedule: 
+  - cron: "0 */24 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: sync the latest tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        res=$(git ls-remote --tags --sort=committerdate|egrep -iv 'helm|rc'|tail -1|awk '{print $2}')
+        echo LATEST_TAG=$res >> $GITHUB_ENV
+    - name: Synchronize repository
+      uses: repo-sync/github-sync@v2
+      with:
+        source_repo: https://github.com/apache/superset
+        source_branch: ${{ env.LATEST_TAG }}
+        destination_branch: upstream
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create pull request
+      uses: repo-sync/pull-request@v2
+      with:
+        source_branch: upstream
+        destination_branch: ortege
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_title: "Pulling ${{ github.ref }} into ortege"
+        pr_body: |
+          :crown: *An automated PR to sync with upstream*
+          
+          Co-authored-by: josedev-union josedev-union@users.noreply.github.com
+        pr_reviewer: "HariSeldon23"


### PR DESCRIPTION
- This PR adds a new gh workflow which fetches the latest stable tag from the upstream repo periodically
- allow dispatch run