### PR TITLE
feat: install prophet pkg

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -17,3 +17,4 @@
 # Ortege specific packages
 apache-superset[databricks]
 Flask-Mail==0.9.1
+prophet==1.1.3


### PR DESCRIPTION
The current latest version of prophet is 1.1.5 but we install 1.1.3 because it has a pkg conflict, specifically `holidays`.