### PR TITLE
ci: sync every week

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync with Upstream
 
 on:
   schedule: 
-  - cron: "0 */24 * * *"
+  - cron: "0 0 * * 0"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The upstream sync PR normally includes conflicts so we have to resolve them. And it requires review before merge so it will take a few days to be merged. So daily force-sync workflow overwrites our fixes every day and it requires us to resolve and review and merge in one day.
This is not practical and annoying surely.
As long as we have dispatch workflow enabled, weekly sync is enough.
